### PR TITLE
feat: template for frontmatter added

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,23 +12,23 @@
 	"author": "kaiiiz",
 	"license": "MIT",
 	"devDependencies": {
-		"@tsconfig/svelte": "^3.0.0",
-		"@types/node": "^16.11.6",
-		"@types/nunjucks": "^3.2.1",
+		"@tsconfig/svelte": "3.0.0",
+		"@types/node": "16.11.6",
+		"@types/nunjucks": "3.2.1",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.14.47",
-		"esbuild-svelte": "^0.7.1",
+		"esbuild-svelte": "0.7.1",
 		"obsidian": "latest",
-		"svelte": "^3.49.0",
-		"svelte-preprocess": "^4.10.7",
+		"svelte": "3.49.0",
+		"svelte-preprocess": "4.10.7",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
 	},
 	"dependencies": {
-		"axios": "^0.27.2",
-		"nunjucks": "^3.2.3",
-		"sanitize-filename": "^1.6.3"
+		"axios": "0.27.2",
+		"nunjucks": "3.2.3",
+		"sanitize-filename": "1.6.3"
 	}
 }

--- a/src/assets/defaultMetadataTemplate.njk
+++ b/src/assets/defaultMetadataTemplate.njk
@@ -1,0 +1,3 @@
+{% if link %}Source URL:: {{link}}{% endif %}
+{% if tags|length %}Tags:{%for tag in tags %}
+ - {{tag}}{% endfor %} {% endif %}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import DEFAULT_TEMPLATE from './assets/defaultTemplate.njk';
+import DEFAULT_METADATA_TEMPLATE from './assets/defaultMetadataTemplate.njk';
 import type { RaindropPluginSettings } from "./types";
 
 export const VERSION = '0.0.13';
@@ -13,6 +14,7 @@ export const DEFAULT_SETTINGS: RaindropPluginSettings = {
 	highlightsFolder: '/',
 	syncCollections: {},
 	template: DEFAULT_TEMPLATE,
+	metadataTemplate: DEFAULT_METADATA_TEMPLATE,
 	dateTimeFormat: 'YYYY/MM/DD HH:mm:ss',
 	autoSyncInterval: 0,
 };

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -49,7 +49,7 @@ export default class Renderer {
 		}
 	}
 
-	renderContent(bookmark: RaindropBookmark, newArticle = true) {
+	renderContent(template:string, bookmark: RaindropBookmark, newArticle = true) {
 		const dateTimeFormat = this.plugin.settings.dateTimeFormat;
 
 		const renderHighlights: RenderHighlight[] = bookmark.highlights.map((hl) => {
@@ -83,19 +83,19 @@ export default class Renderer {
 			type: bookmark.type,
 			important: bookmark.important,
 		};
-
-		const template = this.plugin.settings.template;
+		
 		const content = nunjucks.renderString(template, context);
 		return content;
 	}
 
 	renderFullPost(bookmark: RaindropBookmark) {
-		const newMdContent = this.renderContent(bookmark, true);
+		let newMdContent = this.renderContent(this.plugin.settings.template, bookmark, true);
+		let newMetadataContent = this.renderContent(this.plugin.settings.metadataTemplate, bookmark, true);
 		const frontmatter: BookmarkFileFrontMatter = {
 			raindrop_id: bookmark.id,
 			raindrop_last_update: (new Date()).toISOString(),
 		};
-		const frontmatterStr = stringifyYaml(frontmatter);
+		const frontmatterStr = `${newMetadataContent}\n${stringifyYaml(frontmatter)}`;
 		const mdContent = `---\n${frontmatterStr}---\n${newMdContent}`;
 		return mdContent;
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import {App, Notice, PluginSettingTab, Setting} from 'obsidian';
 import templateInstructions from './templates/templateInstructions.html';
+import metadataTemplateInstructions from './templates/metadataTemplateInstructions.html';
 import datetimeInstructions from './templates/datetimeInstructions.html';
 import appendModeInstructions from './templates/appendModeInstructions.html';
 import type { RaindropAPI } from './api';
@@ -37,6 +38,7 @@ export class RaindropSettingTab extends PluginSettingTab {
 		this.autoSyncInterval();
 		this.dateFormat();
 		this.template();
+		this.metadataTemplate();
 		this.resetSyncHistory();
 	}
 
@@ -224,6 +226,33 @@ export class RaindropSettingTab extends PluginSettingTab {
 				return text;
 			});
 	}
+	private async metadataTemplate(): Promise<void> {
+		const templateDescFragment = document
+			.createRange()
+			.createContextualFragment(metadataTemplateInstructions);
+
+		new Setting(this.containerEl)
+			.setName('Metadata template')
+			.setDesc(templateDescFragment)
+			.addTextArea((text) => {
+				text.inputEl.style.width = '100%';
+				text.inputEl.style.height = '450px';
+				text.inputEl.style.fontSize = '0.8em';
+				text.setValue(this.plugin.settings.metadataTemplate)
+					.onChange(async (value) => {
+						const isValid = this.renderer.validate(value);
+
+						if (isValid) {
+							this.plugin.settings.metadataTemplate = value;
+							await this.plugin.saveSettings();
+						}
+
+						text.inputEl.style.border = isValid ? '' : '1px solid red';
+					});
+				return text;
+			});
+	}
+	
 
 	private resetSyncHistory(): void {
 		new Setting(this.containerEl)

--- a/src/templates/metadataTemplateInstructions.html
+++ b/src/templates/metadataTemplateInstructions.html
@@ -1,0 +1,10 @@
+Metadata Template (<a href="https://mozilla.github.io/nunjucks/">Nunjucks</a>) for
+rendering every synced Raindrop.io highlights & annotations.
+<p>
+	<strong>Please note that this content is going to be pushed to the Frontmatter<br>
+		hence in order to make it work, you have to follow the YAML syntax over Nunjucks</strong>
+	</p>
+<p>
+  <b>Available variables to use are the same as in case of the previous template</b>
+</p>
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export interface RaindropPluginSettings {
 	highlightsFolder: string;
 	syncCollections: SyncCollectionSettings;
 	template: string;
+	metadataTemplate: string;
 	dateTimeFormat: string;
 	autoSyncInterval: number;
 }


### PR DESCRIPTION
Hi @kaiiiz ,
I think these changes implement the feature of updating frontmatter of the Raindrop highlights md raised here https://github.com/kaiiiz/obsidian-raindrop-highlights-plugin/issues/15 and here https://github.com/kaiiiz/obsidian-raindrop-highlights-plugin/issues/10 beside of keeping the raindrop id and the timestamp to make the auto-append work. 
