### PR TITLE
Field to get the collection title in templates + option to disable collections folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This plugin doesn't use the OAuth mechanism. To get your API Token, follow the s
 - `Connect`: Enter API Token in order to pull the highlights from Raindrop
 - `Disconnect`: Remove API Token from Obsidian
 - `Append Mode`: Disabling append mode can keep the synced files with the latest state of the Raindrop articles, but will lose the flexiblity to add or modify the synced files. (i.e. the old file content will be overwritten!)
+-  Enable Collections Folders : Whether to store the articles in folders depending on collections or not
 - `Auto Sync Interval`: Set the interval in minutes to sync Raindrop highlights automatically
 - `Highlights folder`: Specify the folder location for your Raindrop articles
 - `Collection`: Specify the collections to be synced to the vault

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Although there exists a similar project called [Obsidian Raindrop Plugin](https:
 - Update existing files with new highlights and annotations (2 mode supported)
   - Append new highlights to the end of existing file (default)
   - Overwrite the existing file with the the latest Raindrop article highlights and metadata
-- Customization highlights through [Nunjucks](https://mozilla.github.io/nunjucks/) template
+- Customize pulled bookmarks through [Nunjucks](https://mozilla.github.io/nunjucks/) template for both content and front matter
 - Manage Raindrop collections to be synced
 - Auto sync in interval
+- Only sync bookmarks with highlights
 
 ## Usage
 
@@ -45,7 +46,8 @@ This plugin doesn't use the OAuth mechanism. To get your API Token, follow the s
 - `Auto Sync Interval`: Set the interval in minutes to sync Raindrop highlights automatically
 - `Highlights folder`: Specify the folder location for your Raindrop articles
 - `Collection`: Specify the collections to be synced to the vault
-- `Highlights template`: Nunjuck template for rendering your highlights
+- `Content template`: Nunjuck template for rendering the content
+- `Front matter template`: Nunjuck template for rendering the front matter
 - `Reset sync`: Reset last sync time to resync. This operation does not delete any previously synced highlights from your vault
 
 ### To sync all new highlights since previous update

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const DEFAULT_SETTINGS: RaindropPluginSettings = {
 	isConnected: false,
 	ribbonIcon: true,
 	appendMode: true,
+	collectionsFoldersEnabled: true,
 	onlyBookmarksWithHl: false,
 	highlightsFolder: '/',
 	syncCollections: {},

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -25,6 +25,7 @@ type RenderTemplate = {
 	link: string;
 	highlights: RenderHighlight[];
 	collection: RenderCollection;
+	collectionTitle: string;
 	tags: string[];
 	cover: string;
 	created: string;
@@ -51,6 +52,7 @@ const FAKE_RENDER_CONTEXT: RenderTemplate = {
 	collection: {
 		title: "fake_collection",
 	},
+	collectionTitle: "fake_collection",
 	tags: ["fake_tag1", "fake_tag2"],
 	cover: "https://example.com",
 	created: "2022-08-10T01:58:27.457Z",
@@ -137,6 +139,7 @@ export default class Renderer {
 			link: bookmark.link,
 			highlights: renderHighlights,
 			collection: renderCollection,
+			collectionTitle: renderCollection.title,
 			tags: bookmark.tags,
 			cover: bookmark.cover,
 			created: Moment(bookmark.created).format(dateTimeFormat),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,6 +34,7 @@ export class RaindropSettingTab extends PluginSettingTab {
 		this.ribbonIcon();
 		this.onlyBookmarksWithHl();
 		this.appendMode();
+		this.enableCollectionsFolders();
 		this.highlightsFolder();
 		this.collections();
 		this.autoSyncInterval();
@@ -82,6 +83,19 @@ export class RaindropSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.onlyBookmarksWithHl)
 					.onChange(async (value) => {
 						this.plugin.settings.onlyBookmarksWithHl = value;
+						await this.plugin.saveSettings();
+					});
+			});
+	}
+
+	private enableCollectionsFolders(): void {
+		new Setting(this.containerEl)
+			.setName('Store the articles in collections folders')
+			.addToggle((toggle) => {
+				return toggle
+					.setValue(this.plugin.settings.collectionsFoldersEnabled)
+					.onChange(async (value) => {
+						this.plugin.settings.collectionsFoldersEnabled = value;
 						await this.plugin.saveSettings();
 					});
 			});

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -33,7 +33,10 @@ export default class RaindropSync {
 	async syncCollection(collection: SyncCollection) {
 		new Notice(`Sync Raindrop collection: ${collection.title}`);
 		const highlightsFolder = this.plugin.settings.highlightsFolder;
-		const collectionFolder = `${highlightsFolder}/${collection["title"]}`;
+		let collectionFolder = `${highlightsFolder}`
+		if (this.plugin.settings.collectionsFoldersEnabled) {
+			collectionFolder = `${highlightsFolder}/${collection["title"]}`;
+		}
 		const lastSyncDate = this.plugin.settings.syncCollections[collection.id].lastSyncDate;
 
 		let bookmarks: RaindropBookmark[] = [];

--- a/src/templates/templateInstructions.html
+++ b/src/templates/templateInstructions.html
@@ -9,6 +9,7 @@ Article Metadata
 <ul>
   <li><span class="u-pop">{{is_new_article}}</span> (bool) - New file indicator</li>
   <li><span class="u-pop">{{id}}</span> (number) - Article identifier</li>
+	<li><span class="u-pop">{{collectionTitle}}</span> (string) - Collection title</li>
   <li><span class="u-pop">{{title}}</span> (string) - Title</li>
   <li><span class="u-pop">{{excerpt}}</span> (string) - Article excerpt</li>
   <li><span class="u-pop">{{link}}</span> (string) - Link to source</li>

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface RaindropPluginSettings {
 	isConnected: boolean;
 	ribbonIcon: boolean;
 	appendMode: boolean;
+	collectionsFoldersEnabled: boolean;
 	onlyBookmarksWithHl: boolean;
 	highlightsFolder: string;
 	syncCollections: SyncCollectionSettings;


### PR DESCRIPTION
{{collectionTitle}} can be used in templates to get the collection title.
I've also added an option to enable/disable the storage of articles in collections folders.

I needed these two features, so maybe others will need them too?

It's my first pull request, I'm not sure how it works, maybe I've not done the things the right way.