### PR TITLE
Add enable/disable collections folders option

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const DEFAULT_SETTINGS: RaindropPluginSettings = {
 	isConnected: false,
 	ribbonIcon: true,
 	appendMode: true,
+	collectionsFolders: true,
 	onlyBookmarksWithHl: false,
 	highlightsFolder: '/',
 	syncCollections: {},

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,6 +34,7 @@ export class RaindropSettingTab extends PluginSettingTab {
 		this.ribbonIcon();
 		this.onlyBookmarksWithHl();
 		this.appendMode();
+		this.collectionsFolders();
 		this.highlightsFolder();
 		this.collections();
 		this.autoSyncInterval();
@@ -82,6 +83,19 @@ export class RaindropSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.onlyBookmarksWithHl)
 					.onChange(async (value) => {
 						this.plugin.settings.onlyBookmarksWithHl = value;
+						await this.plugin.saveSettings();
+					});
+			});
+	}
+
+	private collectionsFolders(): void {
+		new Setting(this.containerEl)
+			.setName('Store the articles in collections folders')
+			.addToggle((toggle) => {
+				return toggle
+					.setValue(this.plugin.settings.collectionsFolders)
+					.onChange(async (value) => {
+						this.plugin.settings.collectionsFolders = value;
 						await this.plugin.saveSettings();
 					});
 			});

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -33,7 +33,10 @@ export default class RaindropSync {
 	async syncCollection(collection: SyncCollection) {
 		new Notice(`Sync Raindrop collection: ${collection.title}`);
 		const highlightsFolder = this.plugin.settings.highlightsFolder;
-		const collectionFolder = `${highlightsFolder}/${collection["title"]}`;
+		let collectionFolder = `${highlightsFolder}`
+		if (this.plugin.settings.collectionsFolders) {
+			collectionFolder = `${highlightsFolder}/${collection["title"]}`;
+		}
 		const lastSyncDate = this.plugin.settings.syncCollections[collection.id].lastSyncDate;
 
 		let bookmarks: RaindropBookmark[] = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface RaindropPluginSettings {
 	isConnected: boolean;
 	ribbonIcon: boolean;
 	appendMode: boolean;
+	collectionsFolders: boolean;
 	onlyBookmarksWithHl: boolean;
 	highlightsFolder: string;
 	syncCollections: SyncCollectionSettings;


### PR DESCRIPTION
I've added an option to enable/disable the storage of articles in Raindrop collections folders.

If enabled, it's the default behavior. Else, synced articles will be stored in the root of the highlights folder location, and no collections folders will be created.