### PR TITLE
Make cache data available to template

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import { Notice, type App } from "obsidian";
 import axios from "axios";
-import type { RaindropBookmark, RaindropCollection, RaindropHighlight, RaindropUser } from "./types";
+import type { RaindropBookmark, RaindropCache, RaindropCollection, RaindropHighlight, RaindropUser } from "./types";
 import TokenManager from "./tokenManager";
 
 const BASEURL = "https://api.raindrop.io/rest/v1"
@@ -181,6 +181,7 @@ export class RaindropAPI {
 			created: new Date(raindrop['created']),
 			type: raindrop['type'],
 			important: raindrop['important'],
+			cache: this.parseCache(raindrop['cache']),
 		};
 		return bookmark;
 	}
@@ -197,5 +198,14 @@ export class RaindropAPI {
 			};
 			return highlight;
 		});
+	}
+
+	private parseCache(cache: any): RaindropCache {
+		const result: RaindropCache = {
+			status: cache['status'],
+			size: cache['size'],
+			created: new Date(cache['created']),
+		};
+		return result;
 	}
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -13,6 +13,12 @@ type RenderHighlight = {
 	text: string;
 };
 
+type RenderCache = {
+	status: string;
+	size: number;
+	created: string;
+};
+
 type RenderCollection = {
 	title: string;
 };
@@ -30,6 +36,7 @@ type RenderTemplate = {
 	created: string;
 	type: string;
 	important: boolean;
+	cache: RenderCache;
 };
 
 const FAKE_RENDER_CONTEXT: RenderTemplate = {
@@ -56,6 +63,11 @@ const FAKE_RENDER_CONTEXT: RenderTemplate = {
 	created: "2022-08-10T01:58:27.457Z",
 	type: "link",
 	important: false,
+	cache: {
+		status: "fake_status",
+		size: 1234,
+		created: "2022-08-10T01:58:27.457Z",
+	},
 };
 
 export default class Renderer {
@@ -124,6 +136,12 @@ export default class Renderer {
 			return renderHighlight;
 		});
 
+		const renderCache: RenderCache = {
+			status: bookmark.cache.status,
+			size: bookmark.cache.size,
+			created: Moment(bookmark.cache.created).format(dateTimeFormat),
+		}
+
 		// the latest collection data is sync from Raindrop at the beginning of `sync` function
 		const renderCollection: RenderCollection = {
 			title: this.plugin.settings.syncCollections[bookmark.collectionId].title,
@@ -142,6 +160,7 @@ export default class Renderer {
 			created: Moment(bookmark.created).format(dateTimeFormat),
 			type: bookmark.type,
 			important: bookmark.important,
+			cache: renderCache,
 		};
 		
 		const content = nunjucks.renderString(template, context);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3,7 +3,7 @@ import sanitize from "sanitize-filename";
 import type { RaindropAPI } from "./api";
 import type RaindropPlugin from "./main";
 import Renderer from "./renderer";
-import type { BookmarkFile, BookmarkFileFrontMatter, RaindropBookmark, RaindropCollection, SyncCollection } from "./types";
+import type { BookmarkFile, BookmarkFileFrontMatter, RaindropBookmark, RaindropCollection, RaindropCache, SyncCollection } from "./types";
 
 export default class RaindropSync {
 	private app: App;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3,7 +3,7 @@ import sanitize from "sanitize-filename";
 import type { RaindropAPI } from "./api";
 import type RaindropPlugin from "./main";
 import Renderer from "./renderer";
-import type { BookmarkFile, BookmarkFileFrontMatter, RaindropBookmark, RaindropCollection, RaindropCache, SyncCollection } from "./types";
+import type { BookmarkFile, BookmarkFileFrontMatter, RaindropBookmark, RaindropCollection, SyncCollection } from "./types";
 
 export default class RaindropSync {
 	private app: App;

--- a/src/templates/templateInstructions.html
+++ b/src/templates/templateInstructions.html
@@ -18,6 +18,7 @@ Article Metadata
   <li><span class="u-pop">{{created}}</span> (string) - Created on</li>
   <li><span class="u-pop">{{type}}</span> (string) - Article type</li>
   <li><span class="u-pop">{{important}}</span> (bool) - Favorite article</li>
+  <li><span class="u-pop">{{cache}}</span> (Cache) - Cache aka "Permanent Copy"</li>
 </ul>
 
 Collection
@@ -33,4 +34,11 @@ Highlight
   <li><span class="u-pop">{{created}}</span> (string) - Created on</li>
   <li><span class="u-pop">{{lastUpdate}}</span> (string) - Updated on</li>
   <li><span class="u-pop">{{note}}</span> (string) - Annotation</li>
+</ul>
+
+Cache
+<ul>
+  <li><span class="u-pop">{{status}}</span> (string) - Status ('ready', 'failed', etc)</li>
+  <li><span class="u-pop">{{size}}</span> (number) - Size in bytes</li>
+  <li><span class="u-pop">{{created}}</span> (string) - Created on</li>
 </ul>

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,12 @@ export interface RaindropHighlight { // Remote state
 	text: string,
 }
 
+export interface RaindropCache { // Remote state
+	status: string,
+	size: number,
+	created: Date,
+}
+
 export interface RaindropBookmark { // Remote state
 	id: number,
 	collectionId: number,
@@ -31,6 +37,7 @@ export interface RaindropBookmark { // Remote state
 	created: Date,
 	type: string,
 	important: boolean,
+	cache: RaindropCache,
 }
 
 // ----------


### PR DESCRIPTION
Added Permanent Copy data so I can link to it if available. Figured others might like that as well.

- Parses cache ("Permanent Copy") info from the GET response, so it's available to the template renderer. 
- Added it to the template instructions, but not to any defaults, since it requires the Raindrop Pro subscription to be useful.

<img width="363" alt="Screen Shot 2022-12-25 at 04 11 47" src="https://user-images.githubusercontent.com/4853935/209467444-2a417b31-72f5-42e9-b89a-16713004a0b7.png">

Example:
I think this link only redirects successfully if you're already signed into the Raindrop web app in your browser, but it's pretty convenient for that.
```
{% if cache and cache.status === 'ready' -%}
[Permanent Copy](https://api.raindrop.io/v1/raindrop/{{id}}/cache)
{%- endif %}
```