### PR TITLE
fix(api.ts): :bug: fix a bug that prevented full sync of raindrop links

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -143,7 +143,7 @@ export class RaindropAPI {
 		const res = await this.get(`${BASEURL}/raindrops/${collectionId}`, {
 			page: 0,
 			perpage: pageSize,
-			sort: "-lastUpdate",
+			// sort: "-lastUpdate",
 		});
 		const raindropsCnt = res.count;
 		let bookmarks = this.parseRaindrops(res.items);
@@ -155,7 +155,7 @@ export class RaindropAPI {
 			const res = await this.get(`${BASEURL}/raindrops/${collectionId}`, {
 				page: page,
 				perpage: pageSize,
-				sort: "-lastUpdate",
+				// sort: "-lastUpdate",
 			});
 			return this.parseRaindrops(res.items);
 		};


### PR DESCRIPTION
Extension wasn't syncing the whole list, only the most recent one's, resulting in half missing links and their highlights' event when syncing and using the reset multiple times.

The correction came from @KelSolaar in #72, and worked well in my case. Now everything is synced.

There's probably more reflections to do, but at least it gives a starting point on how to fix the plugin for the users.

If someone want to build it, just clone the repo and use : 

```
yarn
yarn build
```

You'll install the dependencies locally and then build the `main.js` file required that you can use to overwrite the one in your vault.