### PR TITLE
[add new setting] support sync all collections by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
 	"dependencies": {
 		"axios": "0.27.2",
 		"axios-retry": "^3.8.0",
+		"moment": "^2.30.1",
 		"nunjucks": "3.2.4",
 		"sanitize-filename": "1.6.3",
 		"semver": "^7.5.2",
+		"truncate-utf8-bytes": "^1.0.2",
 		"ts-md5": "^1.3.1"
 	}
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ export const DEFAULT_SETTINGS: RaindropPluginSettings = {
 	highlightsFolder: "/",
 	collectionGroups: false,
 	autoSyncSuccessNotice: true,
+	syncAllCollections: false,
 	syncCollections: {},
 	template: DEFAULT_TEMPLATE,
 	metadataTemplate: "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,6 +158,11 @@ export default class RaindropPlugin extends Plugin {
 				syncCollections[id] = this.settings.syncCollections[id];
 				syncCollections[id].title = title;
 			}
+
+			// sync all collections
+			if (this.settings.syncAllCollections) {
+				syncCollections[id].sync = true;
+			}
 		});
 		this.settings.syncCollections = syncCollections;
 		await this.saveSettings();

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export interface RaindropPluginSettings {
 	collectionsFolders: boolean;
 	onlyBookmarksWithHl: boolean;
 	highlightsFolder: string;
+	syncAllCollections: boolean;
 	collectionGroups: boolean;
 	syncCollections: SyncCollectionSettings;
 	template: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,6 +694,11 @@ moment@2.29.4:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
+moment@^2.30.1:
+  version "2.30.1"
+  resolved "https://bnpm.byted.org/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -876,6 +881,13 @@ to-regex-range@^5.0.1:
 truncate-utf8-bytes@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  integrity sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==
+  dependencies:
+    utf8-byte-length "^1.0.1"
+
+truncate-utf8-bytes@^1.0.2:
+  version "1.0.2"
+  resolved "https://bnpm.byted.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
   integrity sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==
   dependencies:
     utf8-byte-length "^1.0.1"


### PR DESCRIPTION
In my usage scenario, I need a complete synchronization of all bookmark contents and manage bookmarks with subfolders or even third-level folders. In this case, managing collections becomes extremely complex and requires manual addition of all collections. Therefore, add an option that supports setting default sync for all collections.

My bookmarks look like this 😂：
![image](https://github.com/kaiiiz/obsidian-raindrop-highlights-plugin/assets/13075469/0d97f395-c1fd-46c3-9fd1-fe526d841973)
